### PR TITLE
Align game enums with OpenAPI constants

### DIFF
--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -48,7 +48,7 @@ export interface Game {
     id: string;
     player1Id: string;
     player2Id?: string;
-    status: 'waiting' | 'playing' | 'finished';
+    status: 'WAITING' | 'PLAYING' | 'FINISHED' | 'CANCELLED';
     score: {
         player1: number;
         player2: number;

--- a/services/game-service/src/domain/entities/Game.ts
+++ b/services/game-service/src/domain/entities/Game.ts
@@ -3,7 +3,7 @@ import { Ball } from './Ball';
 import { Paddle } from './Paddle';
 import { GameStatus, Position, Score, Velocity } from '../value-objects';
 
-export type GameMode = 'classic' | 'tournament' | 'ranked' | 'custom';
+export type GameMode = 'CLASSIC' | 'TOURNAMENT' | 'RANKED' | 'CUSTOM';
 
 export interface GameConfig {
     readonly arenaWidth: number;

--- a/services/game-service/src/domain/value-objects/GameStatus.ts
+++ b/services/game-service/src/domain/value-objects/GameStatus.ts
@@ -1,6 +1,6 @@
 export enum GameStatus {
-    WAITING = 'waiting',
-    IN_PROGRESS = 'in_progress',
-    FINISHED = 'finished',
-    CANCELLED = 'cancelled'
+    WAITING = 'WAITING',
+    IN_PROGRESS = 'PLAYING',
+    FINISHED = 'FINISHED',
+    CANCELLED = 'CANCELLED'
 }

--- a/services/game-service/src/infrastructure/http/controllers/GameController.ts
+++ b/services/game-service/src/infrastructure/http/controllers/GameController.ts
@@ -84,14 +84,19 @@ export class GameController {
 }
 
 function mapQueryStatus(status?: string): GameStatus | undefined {
-  switch (status) {
-    case 'WAITING':
+  if (!status) {
+    return undefined;
+  }
+
+  switch (status.toUpperCase()) {
+    case GameStatus.WAITING:
       return GameStatus.WAITING;
     case 'PLAYING':
+    case GameStatus.IN_PROGRESS:
       return GameStatus.IN_PROGRESS;
-    case 'FINISHED':
+    case GameStatus.FINISHED:
       return GameStatus.FINISHED;
-    case 'CANCELLED':
+    case GameStatus.CANCELLED:
       return GameStatus.CANCELLED;
     default:
       return undefined;
@@ -99,17 +104,7 @@ function mapQueryStatus(status?: string): GameStatus | undefined {
 }
 
 function toApiStatus(status: GameStatus): 'WAITING' | 'PLAYING' | 'FINISHED' | 'CANCELLED' {
-  switch (status) {
-    case GameStatus.IN_PROGRESS:
-      return 'PLAYING';
-    case GameStatus.FINISHED:
-      return 'FINISHED';
-    case GameStatus.CANCELLED:
-      return 'CANCELLED';
-    case GameStatus.WAITING:
-    default:
-      return 'WAITING';
-  }
+  return status === GameStatus.IN_PROGRESS ? 'PLAYING' : status;
 }
 
 function resolveWinner(game: GameStateOutput): string | null {

--- a/services/game-service/src/infrastructure/http/validators/createGameValidator.ts
+++ b/services/game-service/src/infrastructure/http/validators/createGameValidator.ts
@@ -10,7 +10,7 @@ export function createGameValidator(payload: unknown, playerId?: string): Create
 
     return {
         playerId,
-      mode: parsed.gameMode.toLowerCase() as CreateGameInput['mode'],
+      mode: parsed.gameMode as CreateGameInput['mode'],
       isPrivate: parsed.isPrivate,
       config: {},
       tournamentId: undefined

--- a/services/game-service/src/infrastructure/messaging/publishers/RabbitMQGameEventPublisher.ts
+++ b/services/game-service/src/infrastructure/messaging/publishers/RabbitMQGameEventPublisher.ts
@@ -32,7 +32,7 @@ export class RabbitMQGameEventPublisher implements IGameEventPublisher {
             gameId: game.id,
             player1Id: player1?.id ?? '',
             player2Id: player2?.id ?? '',
-            gameType: game.mode === 'tournament' ? 'tournament' : 'classic',
+            gameType: game.mode === 'TOURNAMENT' ? 'tournament' : 'classic',
             tournamentId: game.tournamentId,
             startedAt: game.startedAt ?? new Date(),
             gameSettings: {
@@ -56,7 +56,7 @@ export class RabbitMQGameEventPublisher implements IGameEventPublisher {
             finalScore: { player1: game.score.player1, player2: game.score.player2 },
             duration: durationMs / 1000,
             finishedAt,
-            gameType: game.mode === 'tournament' ? 'tournament' : 'classic',
+            gameType: game.mode === 'TOURNAMENT' ? 'tournament' : 'classic',
             tournamentId: game.tournamentId
         });
         await this.publish('game.finished', event);

--- a/services/game-service/tests/unit/application/use-cases/CreateGameUseCase.spec.ts
+++ b/services/game-service/tests/unit/application/use-cases/CreateGameUseCase.spec.ts
@@ -64,7 +64,7 @@ describe('CreateGameUseCase', () => {
         const userClient = new FakeUserClient();
         const useCase = new CreateGameUseCase(repo, publisher, userClient);
 
-        const result = await useCase.execute({ playerId: 'player1', mode: 'classic', config: {} });
+        const result = await useCase.execute({ playerId: 'player1', mode: 'CLASSIC', config: {} });
 
         expect(result.id).toBeDefined();
         expect(publisher.events.length).toBe(1);
@@ -80,7 +80,7 @@ describe('CreateGameUseCase', () => {
             useCase.execute({
                 playerId: 'player1',
                 opponentId: 'ghost',
-                mode: 'classic',
+                mode: 'CLASSIC',
                 config: {}
             })
         ).rejects.toBeInstanceOf(InvalidGameStateError);

--- a/services/game-service/tests/unit/application/use-cases/FinishGameUseCase.spec.ts
+++ b/services/game-service/tests/unit/application/use-cases/FinishGameUseCase.spec.ts
@@ -41,7 +41,7 @@ describe('FinishGameUseCase', () => {
         const repo = new InMemoryRepo();
         const publisher = new FakePublisher();
         const useCase = new FinishGameUseCase(repo, publisher);
-        const game = Game.create({ playerId: 'player1', opponentId: 'player2', mode: 'classic', config: {} });
+        const game = Game.create({ playerId: 'player1', opponentId: 'player2', mode: 'CLASSIC', config: {} });
         game.start();
         await repo.create(game);
 

--- a/services/game-service/tests/unit/domain/entities/Game.spec.ts
+++ b/services/game-service/tests/unit/domain/entities/Game.spec.ts
@@ -4,7 +4,7 @@ import { GameStatus } from '../../../../src/domain/value-objects/GameStatus';
 
 describe('Game entity', () => {
     it('creates a new game with default configuration', () => {
-        const game = Game.create({ playerId: 'player1', mode: 'classic', config: {} });
+        const game = Game.create({ playerId: 'player1', mode: 'CLASSIC', config: {} });
         expect(game.players).toHaveLength(1);
         expect(game.status).toBe(GameStatus.WAITING);
     });

--- a/services/game-service/tests/unit/domain/services/CollisionDetector.spec.ts
+++ b/services/game-service/tests/unit/domain/services/CollisionDetector.spec.ts
@@ -6,7 +6,7 @@ import { Position, Velocity } from '../../../../src/domain/value-objects';
 describe('CollisionDetector', () => {
     it('detects wall collision', () => {
         const detector = new CollisionDetector();
-        const game = Game.create({ playerId: 'player', opponentId: 'opponent', mode: 'classic', config: {} });
+        const game = Game.create({ playerId: 'player', opponentId: 'opponent', mode: 'CLASSIC', config: {} });
         const ball = Ball.create(Position.create(0, 0), Velocity.create(-5, -5));
         const outcome = detector.detect(ball, game);
         expect(outcome.reflectsY).toBe(true);

--- a/services/game-service/tests/unit/domain/services/GamePhysics.spec.ts
+++ b/services/game-service/tests/unit/domain/services/GamePhysics.spec.ts
@@ -5,7 +5,7 @@ import { CollisionDetector } from '../../../../src/domain/services/CollisionDete
 
 describe('GamePhysics', () => {
     it('updates ball position each tick', () => {
-        const game = Game.create({ playerId: 'player', opponentId: 'opponent', mode: 'classic', config: {} });
+        const game = Game.create({ playerId: 'player', opponentId: 'opponent', mode: 'CLASSIC', config: {} });
         game.start();
         const physics = new GamePhysics(new CollisionDetector());
         const originalX = game.ball.position.x;


### PR DESCRIPTION
## Summary
- align game status values with OpenAPI expectations and simplify HTTP status mapping
- keep create-game payloads using uppercase gameMode values throughout the service
- sync shared game types with the uppercase API enums

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69211a7b414c832ca36844f4f954f006)