### PR TITLE
Add authenticated websocket handling

### DIFF
--- a/services/game-service/package.json
+++ b/services/game-service/package.json
@@ -17,12 +17,14 @@
         "amqplib": "^0.10.3",
         "dotenv": "^16.3.1",
         "fastify": "^4.26.0",
+        "jsonwebtoken": "^9.0.2",
         "socket.io": "^4.7.5",
         "sqlite": "^5.1.1",
         "sqlite3": "^5.1.6"
     },
     "devDependencies": {
         "@types/amqplib": "^0.10.1",
+        "@types/jsonwebtoken": "^9.0.5",
         "@types/node": "^20.10.0",
         "tsx": "^4.20.5",
         "typescript": "^5.3.3",

--- a/services/game-service/src/infrastructure/auth/GameAuthService.ts
+++ b/services/game-service/src/infrastructure/auth/GameAuthService.ts
@@ -1,0 +1,48 @@
+import jwt, { JwtPayload } from 'jsonwebtoken';
+import { createGameServiceVault, JWTConfig } from '@transcendence/shared-utils';
+
+export interface AuthContext {
+    readonly playerId: string;
+    readonly claims: JwtPayload;
+}
+
+export class GameAuthService {
+    private readonly vault = createGameServiceVault();
+    private jwtConfig: JWTConfig | null = null;
+
+    private async loadConfig(): Promise<JWTConfig> {
+        if (this.jwtConfig) {
+            return this.jwtConfig;
+        }
+
+        try {
+            await this.vault.initialize();
+            this.jwtConfig = await this.vault.getJWTConfig();
+        } catch (error) {
+            console.warn('Vault unavailable for JWT config, using environment fallback:', (error as Error).message);
+            this.jwtConfig = {
+                secretKey: process.env.JWT_SECRET || 'fallback-jwt-secret-for-development',
+                issuer: process.env.JWT_ISSUER || 'transcendence',
+                expirationHours: Number(process.env.JWT_EXPIRATION_HOURS ?? '24'),
+            };
+        }
+
+        return this.jwtConfig;
+    }
+
+    async verifyToken(token: string): Promise<AuthContext> {
+        const config = await this.loadConfig();
+
+        const claims = jwt.verify(token, config.secretKey, { issuer: config.issuer }) as JwtPayload;
+        const playerId = (claims.sub ?? claims.userId) as string | undefined;
+
+        if (!playerId) {
+            throw new Error('Token payload missing player identifier');
+        }
+
+        return {
+            playerId,
+            claims,
+        };
+    }
+}

--- a/services/game-service/src/infrastructure/auth/index.ts
+++ b/services/game-service/src/infrastructure/auth/index.ts
@@ -1,0 +1,1 @@
+export * from './GameAuthService';

--- a/services/game-service/src/infrastructure/index.ts
+++ b/services/game-service/src/infrastructure/index.ts
@@ -4,3 +4,4 @@ export * from './messaging';
 export * from './external';
 export * from './config';
 export * from './websocket';
+export * from './auth';

--- a/services/game-service/src/infrastructure/websocket/GameRoomManager.ts
+++ b/services/game-service/src/infrastructure/websocket/GameRoomManager.ts
@@ -1,10 +1,5 @@
 import { Server, Socket } from 'socket.io';
 
-export interface JoinPayload {
-    readonly gameId: string;
-    readonly playerId: string;
-}
-
 export class GameRoomManager {
     private readonly roomPlayers = new Map<string, Set<string>>();
     private io?: Server;
@@ -17,12 +12,12 @@ export class GameRoomManager {
         this.io = io;
     }
 
-    join(payload: JoinPayload, socket: Socket): void {
-        const players = this.roomPlayers.get(payload.gameId) ?? new Set<string>();
-        players.add(payload.playerId);
-        this.roomPlayers.set(payload.gameId, players);
-        socket.join(payload.gameId);
-        this.io?.to(payload.gameId).emit('player-joined', { playerId: payload.playerId });
+    join(gameId: string, playerId: string, socket: Socket): void {
+        const players = this.roomPlayers.get(gameId) ?? new Set<string>();
+        players.add(playerId);
+        this.roomPlayers.set(gameId, players);
+        socket.join(gameId);
+        this.io?.to(gameId).emit('player_joined', { playerId });
     }
 
     leave(gameId: string, playerId: string): void {
@@ -35,5 +30,7 @@ export class GameRoomManager {
         if (players.size === 0) {
             this.roomPlayers.delete(gameId);
         }
+
+        this.io?.to(gameId).emit('player_left', { playerId });
     }
 }

--- a/services/game-service/src/infrastructure/websocket/handlers/ConnectionHandler.ts
+++ b/services/game-service/src/infrastructure/websocket/handlers/ConnectionHandler.ts
@@ -1,7 +1,15 @@
 import { Socket } from 'socket.io';
 import { GameLoop } from '../GameLoop';
-import { GameRoomManager, JoinPayload } from '../GameRoomManager';
-import {JoinGameUseCase, StartGameUseCase} from '../../../application/use-cases';
+import { GameRoomManager } from '../GameRoomManager';
+import { JoinGameUseCase, StartGameUseCase } from '../../../application/use-cases';
+
+interface JoinGamePayload {
+    readonly gameId?: string;
+}
+
+interface ReadyPayload {
+    readonly gameId?: string;
+}
 
 export class ConnectionHandler {
     constructor(
@@ -12,15 +20,43 @@ export class ConnectionHandler {
     ) {}
 
     register(socket: Socket): void {
-        socket.on('join-game', async (payload: JoinPayload) => {
-            this.roomManager.join(payload, socket);
+        socket.on('join_game', async (payload: JoinGamePayload) => {
+            const playerId = socket.data.playerId as string | undefined;
+            const gameId = payload?.gameId;
+
+            if (!playerId || !gameId) {
+                socket.emit('error', { message: 'Missing gameId or authenticated player' });
+                return;
+            }
+
+            this.roomManager.join(gameId, playerId, socket);
             try {
-              await this.joinGameUseCase.execute(payload.gameId, payload.playerId);
-                await this.startGameUseCase.execute(payload.gameId);
-                this.gameLoop.start(payload.gameId);
+                await this.joinGameUseCase.execute(gameId, playerId);
             } catch (error) {
                 socket.emit('error', { message: (error as Error).message });
             }
         });
+
+        socket.on('ready', async (payload?: ReadyPayload) => {
+            const playerId = socket.data.playerId as string | undefined;
+            const gameId = payload?.gameId ?? this.getActiveGameId(socket);
+
+            if (!playerId || !gameId) {
+                socket.emit('error', { message: 'Missing gameId or authenticated player' });
+                return;
+            }
+
+            try {
+                await this.startGameUseCase.execute(gameId);
+                this.gameLoop.start(gameId);
+                socket.nsp.to(gameId).emit('game_start', { gameId });
+            } catch (error) {
+                socket.emit('error', { message: (error as Error).message });
+            }
+        });
+    }
+
+    private getActiveGameId(socket: Socket): string | undefined {
+        return [...socket.rooms].find((room) => room !== socket.id);
     }
 }

--- a/services/game-service/src/infrastructure/websocket/handlers/DisconnectHandler.ts
+++ b/services/game-service/src/infrastructure/websocket/handlers/DisconnectHandler.ts
@@ -1,5 +1,5 @@
 import { Socket } from 'socket.io';
-import { DisconnectPlayerUseCase } from   '../../../application/use-cases';
+import { DisconnectPlayerUseCase } from '../../../application/use-cases';
 import { GameRoomManager } from '../GameRoomManager';
 
 export class DisconnectHandler {
@@ -11,12 +11,14 @@ export class DisconnectHandler {
     register(socket: Socket): void {
         socket.on('disconnecting', async () => {
             const rooms = [...socket.rooms].filter((room) => room !== socket.id);
+            const playerId = socket.data.playerId as string | undefined;
+
+            if (!playerId) {
+                return;
+            }
+
             await Promise.all(
                 rooms.map(async (gameId) => {
-                    const playerId = socket.handshake.auth.playerId as string;
-                    if (!playerId) {
-                        return;
-                    }
                     await this.disconnectPlayerUseCase.execute(gameId, playerId);
                     this.roomManager.leave(gameId, playerId);
                 })

--- a/services/game-service/src/infrastructure/websocket/handlers/PaddleMoveHandler.ts
+++ b/services/game-service/src/infrastructure/websocket/handlers/PaddleMoveHandler.ts
@@ -2,16 +2,68 @@ import { Socket } from 'socket.io';
 import { HandlePaddleMoveUseCase } from '../../../application/use-cases';
 import { PaddleMoveInput } from '../../../application/dto';
 
+interface PaddleMovePayload {
+    readonly gameId?: string;
+    readonly direction?: 'up' | 'down';
+    readonly deltaTime?: number;
+    readonly y?: number;
+}
+
 export class PaddleMoveHandler {
     constructor(private readonly handlePaddleMoveUseCase: HandlePaddleMoveUseCase) {}
 
     register(socket: Socket): void {
-        socket.on('paddle-move', async (payload: PaddleMoveInput) => {
+        socket.on('paddle_move', async (payload: PaddleMovePayload) => {
+            const playerId = socket.data.playerId as string | undefined;
+            const gameId = payload?.gameId ?? this.getActiveGameId(socket);
+            const direction = this.resolveDirection(payload);
+            const deltaTime = this.resolveDeltaTime(payload);
+
+            if (!playerId || !gameId || !direction) {
+                socket.emit('error', { message: 'Missing gameId, direction, or authenticated player' });
+                return;
+            }
+
+            const input: PaddleMoveInput = {
+                gameId,
+                playerId,
+                direction,
+                deltaTime,
+            };
+
             try {
-                await this.handlePaddleMoveUseCase.execute(payload);
+                await this.handlePaddleMoveUseCase.execute(input);
             } catch (error) {
                 socket.emit('error', { message: (error as Error).message });
             }
         });
+    }
+
+    private resolveDirection(payload: PaddleMovePayload): 'up' | 'down' | undefined {
+        if (payload.direction) {
+            return payload.direction;
+        }
+
+        if (typeof payload.y === 'number') {
+            return payload.y >= 0 ? 'down' : 'up';
+        }
+
+        return undefined;
+    }
+
+    private resolveDeltaTime(payload: PaddleMovePayload): number {
+        if (typeof payload.deltaTime === 'number') {
+            return payload.deltaTime;
+        }
+
+        if (typeof payload.y === 'number') {
+            return Math.abs(payload.y) || 0.016;
+        }
+
+        return 0.016;
+    }
+
+    private getActiveGameId(socket: Socket): string | undefined {
+        return [...socket.rooms].find((room) => room !== socket.id);
     }
 }

--- a/services/game-service/src/server.ts
+++ b/services/game-service/src/server.ts
@@ -20,7 +20,8 @@ export async function startGameService(): Promise<void> {
             roomManager: container.websocket.roomManager,
             connectionHandler: container.websocket.connectionHandler,
             paddleMoveHandler: container.websocket.paddleMoveHandler,
-            disconnectHandler: container.websocket.disconnectHandler
+            disconnectHandler: container.websocket.disconnectHandler,
+            authService: container.websocket.authService
         });
 
         await app.listen({ port: config.port, host: '0.0.0.0' });


### PR DESCRIPTION
## Summary
- validate `/games/ws` connections with JWT tokens from the `token` query parameter before registering socket event handlers
- align websocket message names with the API spec (`join_game`, `paddle_move`, `ready`, `game_state`, `player_joined`/`player_left`) and route them to existing game lifecycle logic
- derive the connected player identity from verified auth claims for join, paddle movement, and disconnect flows

## Testing
- pnpm install --filter @transcendence/game-service *(fails: registry returned 403 Forbidden)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692121f9e580832c8eefb84a03955c98)