### PR TITLE
Allow unauthenticated health checks

### DIFF
--- a/services/game-service/src/infrastructure/http/middleware/authMiddleware.ts
+++ b/services/game-service/src/infrastructure/http/middleware/authMiddleware.ts
@@ -2,6 +2,10 @@ import { FastifyReply, FastifyRequest } from 'fastify';
 
 export function createAuthMiddleware(expectedApiKey?: string) {
     return async function authMiddleware(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+        if (request.url === '/health') {
+            return;
+        }
+
         if (!expectedApiKey) {
             return;
         }

--- a/services/game-service/src/infrastructure/http/middleware/errorHandler.ts
+++ b/services/game-service/src/infrastructure/http/middleware/errorHandler.ts
@@ -11,9 +11,9 @@ export function registerErrorHandler(app: FastifyInstance): void {
             return reply.status(409).send({ error: error.message });
         }
 
-      if (error instanceof Error && error.message.includes('x-user-id')) {
-        return reply.status(401).send({error: 'Unauthorized'});
-      }
+        if (error instanceof Error && (error.message.includes('x-user-id') || error.message === 'Unauthorized')) {
+            return reply.status(401).send({ error: 'Unauthorized' });
+        }
 
         app.log.error(error, 'Unhandled error');
         return reply.status(500).send({ error: 'Internal Server Error' });


### PR DESCRIPTION
## Summary
- allow /health endpoint to bypass internal API key enforcement
- return proper 401 responses for authorization failures instead of 500s

## Testing
- pnpm --filter @transcendence/game-service test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921179a6ec4832c8dd065edf60af2d6)