### PR TITLE
Implement game-ready endpoint for player readiness tracking

### DIFF
--- a/apps/web/src/modules/game/components/GameLobby.ts
+++ b/apps/web/src/modules/game/components/GameLobby.ts
@@ -290,8 +290,7 @@ export class GameLobby extends Component<GameLobbyProps, GameLobbyState> {
 
   private async handleReady(): Promise<void> {
     try {
-      // TODO: Implement ready endpoint when backend is ready
-      // For now, just update local state
+      await httpClient.post(`/games/${this.props.gameId}/ready`, {});
       this.state.isReady = true;
       this.update({});
     } catch (error) {

--- a/docs/api/paths/games.yaml
+++ b/docs/api/paths/games.yaml
@@ -111,6 +111,28 @@
       '404':
         description: Game not found
 
+/games/{gameId}/ready:
+  post:
+    tags: [Games]
+    operationId: Games_readyUp
+    summary: Mark current player as ready
+    parameters:
+      - name: gameId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    responses:
+      '204':
+        description: Player marked ready (game may start when all ready)
+      '400':
+        description: Cannot ready up
+      '401':
+        description: Not authenticated
+      '404':
+        description: Game not found
+
 /games/{gameId}/leave:
   post:
     tags: [Games]

--- a/docs/development/milestone-integration.md
+++ b/docs/development/milestone-integration.md
@@ -1,0 +1,37 @@
+# Milestone: Frontend to API Gateway to Game/User Integration
+
+Scope: ship an end-to-end path that uses the API gateway and Vault-backed services for auth, friendship, and game play (HTTP + WS). Keep local arcade mode intact; add online flows via gateway.
+
+## Current State Snapshot
+- Backend: game-service HTTP + Socket.IO ready; handles `user-deleted` and tournament events; exposed through gateway proxies.
+- Gateway: HTTP routes wired; WS proxy for `/api/games/ws` exists (prefix stripped, needs correct client path).
+- Frontend: HttpClient with refresh/2FA, GameLobby UI, local-only canvas play, WebSocket client factory (unused in UI), user/friend features UI partially present but not fully wired.
+- Docs: split OpenAPI files present; some endpoints not aligned with actual payloads; Vault configs exist per service.
+- Gap: user-service currently not emitting the `user-deleted` event that game-service already consumes.
+
+## Proposed Issues (assignable to 4 owners)
+1) **Online game flow (frontend + gateway)**  
+   - Wire lobby/game pages to `GameService` via `httpClient` through gateway (`/api/games`).  
+   - Use new WS defaults (`VITE_WS_GAME_URL`, `VITE_WS_GAME_PATH=/api/games/ws/socket.io`) to join/ready/send inputs; render remote state in canvas.  
+   - Error/loading/timeout states handled; fallback mock behind a dev flag only.
+
+2) **Auth + profile integration (frontend)**  
+   - Hook login/register to `/api/auth/*` with HttpClient refresh; persist tokens in `appState`.  
+   - Fetch `/api/users/me` on app load/dashboard; show profile and friendship status (read-only is fine this sprint).  
+   - Add logout path that clears tokens and redirects via HttpClient logout.
+
+3) **User-service to game-service events (backend)**  
+   - Emit `user-deleted` (and basic status changes if available) from user-service to the event bus; document contract.  
+   - Add integration test that game-service receives and cancels active games for deleted users.  
+   - Update infra/env to ensure gateway has credentials for the broker if needed.
+
+4) **API spec + Vault/env alignment (cross-team)**  
+   - Update `docs/api/paths/games.yaml` and related schemas to match current gateway/game-service payloads (include WS path note).  
+   - Add README snippet for `VITE_WS_GAME_URL`/`VITE_WS_GAME_PATH` defaults and gateway WS usage.  
+   - Verify Vault secrets/templates for api-gateway/game-service include internal API key + URLs referenced in docs.
+
+## Acceptance Markers for the Milestone
+- A logged-in user can create/join a game through the gateway and see it in the lobby.  
+- WS connection established via `/api/games/ws/socket.io` with token query; game state events reach the canvas.  
+- Deleting a user triggers cleanup in game-service (test proves it).  
+- Docs and env defaults reflect the above; no "magic" localhost ports left undocumented.

--- a/infrastructure/api-gateway/src/routes/games.routes.ts
+++ b/infrastructure/api-gateway/src/routes/games.routes.ts
@@ -147,6 +147,38 @@ export async function registerGameRoutes(
     });
 
     /**
+     * POST /api/games/:gameId/ready
+     * Protected - Mark player as ready
+     */
+    fastify.post('/api/games/:gameId/ready', {
+        preHandler: [
+            requireAuth,
+            validateRequestParams(gameIdParamSchema)
+        ]
+    }, async (request, reply) => {
+        const user = getUser(request);
+        const { gameId } = request.params as { gameId: string };
+
+        const response = await fetch(`${gameServiceUrl}/games/${gameId}/ready`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'x-internal-api-key': internalApiKey,
+                'x-request-id': request.id,
+                'x-user-id': user?.userId || user?.sub || '',
+                'Authorization': request.headers.authorization || '',
+            },
+        });
+
+        if (response.status === 204) {
+            return reply.code(response.status).send();
+        }
+
+        const data = await response.json();
+        return reply.code(response.status).send(data);
+    });
+
+    /**
      * POST /api/games/:gameId/leave
      * Protected - Leave game
      */

--- a/services/game-service/src/application/use-cases/game-management/ReadyUpUseCase.ts
+++ b/services/game-service/src/application/use-cases/game-management/ReadyUpUseCase.ts
@@ -1,0 +1,39 @@
+import { GameStatus } from '../../../domain/value-objects';
+import { GameNotFoundError, InvalidGameStateError } from '../../../domain/errors';
+import { IGameRepository } from '../../ports/repositories/IGameRepository';
+import { IGameEventPublisher } from '../../ports/messaging/IGameEventPublisher';
+
+export class ReadyUpUseCase {
+    constructor(
+        private readonly gameRepository: IGameRepository,
+        private readonly eventPublisher: IGameEventPublisher
+    ) {}
+
+    async execute(gameId: string, playerId: string): Promise<{ started: boolean }> {
+        const game = await this.gameRepository.findById(gameId);
+        if (!game) {
+            throw new GameNotFoundError(gameId);
+        }
+
+        const isParticipant = game.players.some((player) => player.id === playerId);
+        if (!isParticipant) {
+            throw new InvalidGameStateError('Player is not part of this game');
+        }
+
+        const everyoneReady = game.markPlayerReady(playerId);
+
+        if (everyoneReady && game.status === GameStatus.WAITING) {
+            game.start();
+        }
+
+        await this.gameRepository.update(game);
+
+        let started = false;
+        if (everyoneReady && game.status === GameStatus.IN_PROGRESS) {
+            await this.eventPublisher.publishGameStarted(game);
+            started = true;
+        }
+
+        return { started };
+    }
+}

--- a/services/game-service/src/application/use-cases/game-management/index.ts
+++ b/services/game-service/src/application/use-cases/game-management/index.ts
@@ -5,4 +5,5 @@ export * from './GetGameUseCase';
 export * from './ListGamesUseCase';
 export * from './JoinGameUseCase';
 export * from './LeaveGameUseCase';
+export * from './ReadyUpUseCase';
 export type {ListGamesResult} from './ListGamesUseCase';

--- a/services/game-service/tests/helpers/testContext.ts
+++ b/services/game-service/tests/helpers/testContext.ts
@@ -13,6 +13,7 @@ import {
     StartGameUseCase,
     UpdateGameStateUseCase,
     DisconnectPlayerUseCase,
+    ReadyUpUseCase,
 } from '../../src/application/use-cases';
 import { IGameEventPublisher } from '../../src/application/ports/messaging/IGameEventPublisher';
 import { IUserServiceClient } from '../../src/application/ports/external/IUserServiceClient';
@@ -73,6 +74,7 @@ export async function createTestContext() {
     const handlePaddleMove = new HandlePaddleMoveUseCase(repository, physics, eventPublisher);
     const updateGameState = new UpdateGameStateUseCase(repository, physics, eventPublisher);
     const disconnectPlayer = new DisconnectPlayerUseCase(repository);
+    const readyUp = new ReadyUpUseCase(repository, eventPublisher);
 
     const gameController = new GameController({
         createGameUseCase: createGame,
@@ -80,6 +82,8 @@ export async function createTestContext() {
         getGameUseCase: getGame,
         joinGameUseCase: joinGame,
         leaveGameUseCase: leaveGame,
+        readyUpUseCase: readyUp,
+        gameLoop: new GameLoop(updateGameState, 10),
     });
     const healthController = new HealthController();
 
@@ -110,6 +114,7 @@ export async function createTestContext() {
             handlePaddleMove,
             updateGameState,
             disconnectPlayer,
+            readyUp,
         },
         controllers: { gameController, healthController },
         httpServer,

--- a/services/game-service/tests/integration/websocket/game-websocket.test.ts
+++ b/services/game-service/tests/integration/websocket/game-websocket.test.ts
@@ -29,7 +29,7 @@ describe('Game websocket', () => {
             roomManager,
             gameLoop as any,
             context.useCases.joinGame,
-            context.useCases.startGame,
+            context.useCases.readyUp,
         );
         const paddleMoveHandler = new PaddleMoveHandler(context.useCases.handlePaddleMove);
         const disconnectHandler = new DisconnectHandler(
@@ -74,6 +74,7 @@ describe('Game websocket', () => {
         expect(joinedEvents.some((event) => event?.playerId === PLAYER_2)).toBe(true);
 
         await socket1.dispatch('ready', { gameId: game.id });
+        await socket2.dispatch('ready', { gameId: game.id });
 
         const afterStart = await context.useCases.getGame.execute(game.id);
         expect(afterStart.status).toBe(GameStatus.IN_PROGRESS);

--- a/services/game-service/tests/unit/application/use-cases/ReadyUpUseCase.spec.ts
+++ b/services/game-service/tests/unit/application/use-cases/ReadyUpUseCase.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ReadyUpUseCase } from '../../../../src/application/use-cases';
+import { IGameRepository, ListGamesParams } from '../../../../src/application/ports/repositories/IGameRepository';
+import { Game } from '../../../../src/domain/entities';
+import { GameStatus } from '../../../../src/domain/value-objects';
+import { IGameEventPublisher } from '../../../../src/application/ports/messaging/IGameEventPublisher';
+
+class InMemoryGameRepository implements IGameRepository {
+    private games = new Map<string, Game>();
+
+    constructor(initialGame?: Game) {
+        if (initialGame) {
+            this.games.set(initialGame.id, initialGame);
+        }
+    }
+
+    async create(game: Game): Promise<void> {
+        this.games.set(game.id, game);
+    }
+
+    async update(game: Game): Promise<void> {
+        this.games.set(game.id, game);
+    }
+
+    async findById(id: string): Promise<Game | null> {
+        return this.games.get(id) ?? null;
+    }
+
+    // Unused in these tests
+    async list(_params?: ListGamesParams): Promise<Game[]> {
+        return Array.from(this.games.values());
+    }
+
+    async findActiveByPlayer(playerId: string): Promise<Game | null> {
+        for (const game of this.games.values()) {
+            if (game.players.some((player) => player.id === playerId)) {
+                return game;
+            }
+        }
+        return null;
+    }
+}
+
+class NoopEventPublisher implements IGameEventPublisher {
+    publishGameCreated = vi.fn();
+    publishGameStarted = vi.fn();
+    publishGameFinished = vi.fn();
+    publishGameCancelled = vi.fn();
+    publishGameStateUpdated = vi.fn();
+}
+
+describe('ReadyUpUseCase', () => {
+    let repository: InMemoryGameRepository;
+    let publisher: NoopEventPublisher;
+    let useCase: ReadyUpUseCase;
+    let game: Game;
+
+    beforeEach(() => {
+        game = Game.create({
+            playerId: 'p1',
+            opponentId: 'p2',
+            mode: 'CLASSIC',
+            config: {},
+        });
+        repository = new InMemoryGameRepository(game);
+        publisher = new NoopEventPublisher();
+        useCase = new ReadyUpUseCase(repository, publisher);
+    });
+
+    it('marks a player ready but does not start when only one player is ready', async () => {
+        const result = await useCase.execute(game.id, 'p1');
+
+        const updated = await repository.findById(game.id);
+        expect(result.started).toBe(false);
+        expect(updated?.players.find((p) => p.id === 'p1')?.ready).toBe(true);
+        expect(updated?.status).toBe(GameStatus.WAITING);
+        expect(publisher.publishGameStarted).not.toHaveBeenCalled();
+    });
+
+    it('starts the game and publishes when all players are ready', async () => {
+        await useCase.execute(game.id, 'p1');
+        const result = await useCase.execute(game.id, 'p2');
+
+        const updated = await repository.findById(game.id);
+        expect(result.started).toBe(true);
+        expect(updated?.status).toBe(GameStatus.IN_PROGRESS);
+        expect(publisher.publishGameStarted).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws if non participant tries to ready up', async () => {
+        await expect(useCase.execute(game.id, 'intruder')).rejects.toThrow();
+    });
+});


### PR DESCRIPTION
This pull request introduces the `game-ready` endpoint and its accompanying `ReadyUpUseCase` to enable tracking of player readiness within the game. This feature ensures that all players have confirmed readiness before proceeding.