### PR TITLE
Add websocket event reference and developer quickstart docs

### DIFF
--- a/docs/api/websocket-events.yaml
+++ b/docs/api/websocket-events.yaml
@@ -1,0 +1,316 @@
+name: WebSocketEvents
+version: 0.1.0
+description: |
+  Socket.IO event contracts for real-time Pong gameplay and chat.
+  Connections terminate at the API Gateway by default and are proxied to
+  the game service's Socket.IO server. Clients may also connect directly to
+  the game service during local development.
+
+endpoint:
+  transport: socket.io
+  gateway:
+    url: http://localhost:3000
+    path: /api/games/ws/socket.io
+  direct:
+    url: http://localhost:3002
+    path: /socket.io
+  notes: |
+    - The gateway strips the `/api/games/ws` prefix and forwards traffic to the
+      game-service Socket.IO server.
+    - Chat uses the same Socket.IO connection and namespace; chat-specific
+      events are included below.
+
+authentication:
+  method: JWT
+  carrier: query
+  parameter: token
+  example: http://localhost:3000/api/games/ws/socket.io/?token=<jwt>
+  failureEvents:
+    - event: error
+      payload:
+        type: object
+        properties:
+          message:
+            type: string
+        example:
+          message: "Unauthorized: missing token"
+
+client_to_server_events:
+  join_game:
+    summary: Join a game room and subscribe to state updates.
+    payloadSchema:
+      type: object
+      required: [gameId]
+      properties:
+        gameId:
+          type: string
+          format: uuid
+    example:
+      gameId: "8bb9026f-9959-4a0d-9f4b-1b814b6aeb24"
+    emitsOnError:
+      - error
+
+  ready:
+    summary: Signal readiness; starts the loop once all players are ready.
+    payloadSchema:
+      type: object
+      properties:
+        gameId:
+          type: string
+          format: uuid
+    example:
+      gameId: "8bb9026f-9959-4a0d-9f4b-1b814b6aeb24"
+    emitsOnError:
+      - error
+
+  paddle_move:
+    summary: Update paddle intent for the current tick.
+    payloadSchema:
+      type: object
+      required: [direction]
+      properties:
+        gameId:
+          type: string
+          format: uuid
+        direction:
+          type: string
+          enum: [up, down]
+        deltaTime:
+          type: number
+          description: Client-side delta in seconds (fallback 0.016s if omitted).
+        y:
+          type: number
+          description: Optional analog input; translated to a direction when provided.
+    example:
+      gameId: "8bb9026f-9959-4a0d-9f4b-1b814b6aeb24"
+      direction: down
+      deltaTime: 0.016
+    emitsOnError:
+      - error
+
+  send_message:
+    summary: Send a chat message tied to a game room or direct recipient.
+    payloadSchema:
+      type: object
+      required: [content]
+      properties:
+        content:
+          type: string
+        gameId:
+          type: string
+          format: uuid
+        recipientId:
+          type: string
+          format: uuid
+    examples:
+      - content: "gg wp"
+        gameId: "8bb9026f-9959-4a0d-9f4b-1b814b6aeb24"
+      - content: "Ready?"
+        recipientId: "6fe471c9-a8c8-4410-a9d7-28b301a8f8df"
+    emitsOnError:
+      - error
+
+  typing:
+    summary: Emit a typing indicator for chat.
+    payloadSchema:
+      type: object
+      properties:
+        recipientId:
+          type: string
+          format: uuid
+    example:
+      recipientId: "6fe471c9-a8c8-4410-a9d7-28b301a8f8df"
+
+server_to_client_events:
+  game_state:
+    summary: Game loop broadcast with authoritative state.
+    payloadSchema:
+      type: object
+      required: [ball, paddles, score]
+      properties:
+        gameId:
+          type: string
+          format: uuid
+        ball:
+          type: object
+          properties:
+            x:
+              type: number
+            y:
+              type: number
+            velocityX:
+              type: number
+            velocityY:
+              type: number
+        paddles:
+          type: object
+          properties:
+            left:
+              type: object
+              properties:
+                y:
+                  type: number
+            right:
+              type: object
+              properties:
+                y:
+                  type: number
+        score:
+          type: object
+          properties:
+            left:
+              type: integer
+            right:
+              type: integer
+    example:
+      gameId: "8bb9026f-9959-4a0d-9f4b-1b814b6aeb24"
+      ball: { x: 120, y: 90, velocityX: 320, velocityY: -240 }
+      paddles:
+        left: { y: 80 }
+        right: { y: 110 }
+      score: { left: 3, right: 2 }
+
+  game_start:
+    summary: Indicates the countdown/start signal for a match.
+    payloadSchema:
+      type: object
+      required: [gameId]
+      properties:
+        gameId:
+          type: string
+          format: uuid
+    example:
+      gameId: "8bb9026f-9959-4a0d-9f4b-1b814b6aeb24"
+
+  game_end:
+    summary: Final result for a completed match.
+    payloadSchema:
+      type: object
+      required: [gameId, winnerId, finalScore]
+      properties:
+        gameId:
+          type: string
+          format: uuid
+        winnerId:
+          type: string
+          format: uuid
+        finalScore:
+          type: object
+          properties:
+            left:
+              type: integer
+            right:
+              type: integer
+    example:
+      gameId: "8bb9026f-9959-4a0d-9f4b-1b814b6aeb24"
+      winnerId: "6fe471c9-a8c8-4410-a9d7-28b301a8f8df"
+      finalScore: { left: 5, right: 2 }
+
+  player_joined:
+    summary: Another player entered the room.
+    payloadSchema:
+      type: object
+      required: [playerId]
+      properties:
+        playerId:
+          type: string
+          format: uuid
+    example:
+      playerId: "6fe471c9-a8c8-4410-a9d7-28b301a8f8df"
+
+  player_left:
+    summary: A player disconnected or left the room.
+    payloadSchema:
+      type: object
+      required: [playerId]
+      properties:
+        playerId:
+          type: string
+          format: uuid
+    example:
+      playerId: "e1bfbef3-28f3-4cac-b58d-836cab1a8c59"
+
+  new_message:
+    summary: Chat message delivery.
+    payloadSchema:
+      type: object
+      required: [message]
+      properties:
+        message:
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            senderId:
+              type: string
+              format: uuid
+            content:
+              type: string
+            createdAt:
+              type: string
+              format: date-time
+            gameId:
+              type: string
+              format: uuid
+            recipientId:
+              type: string
+              format: uuid
+    example:
+      message:
+        id: "f9a2e9fb-0b8f-45bb-9c02-f22f37c9c5e1"
+        senderId: "6fe471c9-a8c8-4410-a9d7-28b301a8f8df"
+        content: "Nice block!"
+        createdAt: "2024-04-21T12:34:56.000Z"
+        gameId: "8bb9026f-9959-4a0d-9f4b-1b814b6aeb24"
+
+  user_typing:
+    summary: Typing indicator for chat participants.
+    payloadSchema:
+      type: object
+      required: [userId]
+      properties:
+        userId:
+          type: string
+          format: uuid
+        username:
+          type: string
+    example:
+      userId: "6fe471c9-a8c8-4410-a9d7-28b301a8f8df"
+      username: "pongster42"
+
+  user_online:
+    summary: Presence signal indicating a user came online.
+    payloadSchema:
+      type: object
+      required: [userId]
+      properties:
+        userId:
+          type: string
+          format: uuid
+    example:
+      userId: "6fe471c9-a8c8-4410-a9d7-28b301a8f8df"
+
+  user_offline:
+    summary: Presence signal indicating a user went offline.
+    payloadSchema:
+      type: object
+      required: [userId]
+      properties:
+        userId:
+          type: string
+          format: uuid
+    example:
+      userId: "e1bfbef3-28f3-4cac-b58d-836cab1a8c59"
+
+  error:
+    summary: Error envelope emitted by the server.
+    payloadSchema:
+      type: object
+      required: [message]
+      properties:
+        message:
+          type: string
+    examples:
+      - message: "Missing gameId or authenticated player"
+      - message: "Unauthorized: missing token"

--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -1,0 +1,61 @@
+# Getting Started (Under 10 Minutes)
+
+This quickstart walks a new contributor from clone to a running gateway, game-service, and web client fast. It links to env examples and the WebSocket guide for deeper context.
+
+## 1) Clone and toolchain
+```bash
+# Ensure pnpm is available
+corepack enable
+
+# Clone and enter the repo
+git clone https://github.com/NourMellal/transcendence.git
+cd transcendence
+```
+
+## 2) Install dependencies
+```bash
+pnpm install
+```
+> Tip: pnpm is already vendored via `corepack`; no manual install is needed.
+
+## 3) Prepare env files
+Copy the provided examples so services boot without hunting for secrets:
+```bash
+cp .env.example .env
+cp services/game-service/.env.example services/game-service/.env
+```
+See the full examples in [root `.env.example`](../../.env.example) and [game-service `.env.example`](../../services/game-service/.env.example) before changing anything.
+
+## 4) Start required infra (RabbitMQ, Redis, Vault)
+```bash
+pnpm docker:up
+```
+This uses `docker-compose.yml` to start all supporting containers in detached mode.
+
+## 5) Launch gateway + game-service + web (three terminals)
+```bash
+# Terminal 1 - API Gateway
+pnpm dev:gateway
+
+# Terminal 2 - Game Service
+pnpm dev:game
+
+# Terminal 3 - Web client
+pnpm dev:web
+```
+Navigate to `http://localhost:4173` (Vite dev server) and log in/register via the gateway at `http://localhost:3000`.
+
+## 6) Connect to WebSockets
+The SPA uses Socket.IO to reach the game loop. The defaults already point at the gateway proxy (`VITE_WS_GAME_URL=http://localhost:3000`, `VITE_WS_GAME_PATH=/api/games/ws/socket.io`). If you need to override them, follow the [WebSocket Setup Guide](./websocket-setup.md).
+
+## 7) Run the full stack later
+When you have more time or need other services:
+```bash
+pnpm dev:all
+```
+This spawns user, chat, tournament, gateway, and web concurrently.
+
+## Troubleshooting
+- Containers not starting? Run `pnpm docker:logs` to view the compose output.
+- WebSocket 401 or handshake errors? Double-check your JWT token in the query string per the [WebSocket events reference](../api/websocket-events.yaml).
+- Need a clean slate? Stop services with `Ctrl+C` in each terminal and bring down infra via `pnpm docker:down`.

--- a/docs/development/websocket-setup.md
+++ b/docs/development/websocket-setup.md
@@ -1,0 +1,72 @@
+# WebSocket Setup Guide
+
+This guide explains how to connect to the Socket.IO endpoint exposed by the API Gateway and how to bypass the gateway to hit the game-service directly during local troubleshooting.
+
+## Connection Modes
+
+### Through the API Gateway (recommended)
+- **URL:** `http://localhost:3000`
+- **Path:** `/api/games/ws/socket.io`
+- **When to use:** Default for local dev, staging, and production; keeps the gateway's auth, rate limits, and path stripping in place.
+
+### Direct to game-service (debugging only)
+- **URL:** `http://localhost:3002`
+- **Path:** `/socket.io`
+- **When to use:** Narrow debugging of game-service WebSocket handlers when gateway configuration might be masking the issue.
+
+## Environment Variable Combinations (frontend)
+| Mode | `VITE_WS_GAME_URL` | `VITE_WS_GAME_PATH` | Notes |
+| ---- | ------------------ | ------------------- | ----- |
+| Gateway (default) | `http://localhost:3000` | `/api/games/ws/socket.io` | Matches the proxy defined in `docs/api/paths/games.yaml` and the SPA defaults. |
+| Direct game-service | `http://localhost:3002` | `/socket.io` | Bypasses the gateway; keep REST calls pointing at the gateway to avoid mixed auth flows. |
+| Remote gateway | `<https://gateway.example.com>` | `/api/games/ws/socket.io` | Use when testing against a deployed stack. |
+
+> Tip: Set these variables in your `.env.local` inside `apps/web` or via `VITE_WS_GAME_URL=<...> VITE_WS_GAME_PATH=<...> pnpm dev:web`.
+
+## Authentication
+- The Socket.IO handshake requires a **JWT** passed as `?token=<jwt>` in the query string.
+- Tokens are issued by the gateway's HTTP login flow; reuse the same token the SPA stores for REST calls.
+- A missing or invalid token triggers an `error` event payload with a message such as `Unauthorized: missing token`.
+
+## Troubleshooting Checklist
+1. **Handshake fails immediately:**
+   - Ensure the URL + path combination matches the mode you're using; the gateway path includes `/api/games/ws`.
+   - Confirm the `token` query parameter is present and not expired.
+2. **CORS/socket transport errors:**
+   - In direct mode, verify the game-service allows your origin; the default server enables `cors: { origin: '*' }` for local dev.
+3. **Joined but no game updates:**
+   - Send a `join_game` event with the `gameId` from the REST lobby API before emitting `ready` or `paddle_move`.
+   - Keep `deltaTime` small (e.g., `0.016`) to match the game loop cadence.
+4. **Gateway proxy quirks:**
+   - If the gateway rewrites paths incorrectly, test direct mode to isolate.
+   - Check the gateway logs for 401/426 responses while connecting.
+
+## Quick Testing Snippets
+
+### Node one-liner
+```bash
+node -e "const { io } = require('socket.io-client'); const socket = io('http://localhost:3000', { path: '/api/games/ws/socket.io', query: { token: process.env.TOKEN } }); socket.on('connect', () => socket.emit('join_game', { gameId: process.env.GAME_ID })); socket.on('game_state', console.log); socket.on('error', console.error);"
+```
+
+### Minimal TypeScript client
+```ts
+import { io, Socket } from 'socket.io-client';
+
+const socket: Socket = io('http://localhost:3000', {
+  path: '/api/games/ws/socket.io',
+  query: { token: '<jwt>' },
+});
+
+socket.on('connect', () => {
+  socket.emit('join_game', { gameId: '<uuid>' });
+  socket.emit('ready', { gameId: '<uuid>' });
+});
+
+socket.on('game_state', (state) => console.log('tick', state));
+socket.on('error', (err) => console.error('ws error', err));
+```
+
+## Related Docs
+- Event-level contracts: [`docs/api/websocket-events.yaml`](../api/websocket-events.yaml)
+- REST/WebSocket path reference: [`docs/api/paths/games.yaml`](../api/paths/games.yaml)
+- Environment examples: root [`./.env.example`](../../.env.example) and service-specific [`./services/game-service/.env.example`](../../services/game-service/.env.example)


### PR DESCRIPTION
## Summary
- add Socket.IO event contract reference covering gameplay and chat payloads
- document gateway vs direct websocket setup with env combinations and troubleshooting steps
- create fast developer getting-started guide linking to env examples and websocket docs

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692959d3e950832c8133f187c7e74193)