### PR TITLE
Add env example coverage for gateway and frontend configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,60 +1,72 @@
-# ========================================PORT=3001
+########################################
+# Environment mode & logging
+########################################
+NODE_ENV=development
+HOST=0.0.0.0
+LOG_LEVEL=info
 
-# Transcendence - Environment ConfigurationHOST=0.0.0.0
+########################################
+# Public gateway endpoints for the SPA and tools
+########################################
+GATEWAY_HTTP_URL=http://localhost:3000
+GATEWAY_WS_URL=ws://localhost:3000
+API_BASE_PATH=/api
+GATEWAY_WS_GAME_PATH=/api/games/ws/socket.io
+GATEWAY_WS_CHAT_PATH=/api/chat/ws
+CORS_ORIGIN=http://localhost:3000
 
-# ========================================LOG_LEVEL=info
-
-# Copy this file to .env and the project will work out of the box!JWT_SECRET=jwt_secret_example
-
-# No need to change anything for local development.CORS_ORIGIN=http://localhost:3000
-
-
-# ========================================
-# Vault Configuration (HashiCorp Vault)
-# ========================================
-# Vault stores all sensitive secrets securely
-# For development, these defaults work automatically
+########################################
+# Vault configuration (preferred source for secrets)
+########################################
 VAULT_ADDR=http://localhost:8200
 VAULT_TOKEN=dev-root-token
 VAULT_SKIP_VERIFY=true
 
-# ========================================
-# Service Ports
-# ========================================
+########################################
+# Service ports (local development)
+########################################
+API_GATEWAY_PORT=3000
 USER_SERVICE_PORT=3001
 GAME_SERVICE_PORT=3002
 CHAT_SERVICE_PORT=3003
 TOURNAMENT_SERVICE_PORT=3004
-API_GATEWAY_PORT=3000
 
-# ========================================
-# Database Configuration
-# ========================================
-# SQLite databases for User and Tournament services
+########################################
+# Service URLs the gateway will route to
+########################################
+USER_SERVICE_URL=http://localhost:3001
+GAME_SERVICE_URL=http://localhost:3002
+CHAT_SERVICE_URL=http://localhost:3003
+TOURNAMENT_SERVICE_URL=http://localhost:3004
+
+########################################
+# Database configuration (local SQLite defaults)
+########################################
 USER_SERVICE_DB_PATH=./services/user-service/user-service.db
 TOURNAMENT_SERVICE_DB_PATH=./services/tournament-service/tournament-service.db
 
-# Redis Configuration (for Game & Chat services)
+########################################
+# Redis configuration (Game & Chat services)
+########################################
 REDIS_HOST=localhost
 REDIS_PORT=6379
 GAME_SERVICE_REDIS_DB=0
 CHAT_SERVICE_REDIS_DB=1
 
-# ========================================
-# General Settings
-# ========================================
-NODE_ENV=development
-LOG_LEVEL=info
-HOST=0.0.0.0
-
-# ========================================
-# CORS Configuration
-# ========================================
-CORS_ORIGIN=http://localhost:3000
-
-# ========================================
-# JWT Fallback (only used if Vault unavailable)
-# ========================================
-# Note: In production, JWT secrets are managed by Vault
+########################################
+# JWT fallback (only used if Vault is unavailable)
+# In production, JWT secrets are sourced from Vault.
+########################################
 JWT_SECRET=your-secret-key-change-in-production
 JWT_EXPIRES_IN=24h
+
+########################################
+# Rate limiting defaults for the gateway
+########################################
+RATE_LIMIT_MAX=100
+RATE_LIMIT_WINDOW=1 minute
+
+########################################
+# Internal communication
+########################################
+INTERNAL_API_KEY=replace-with-generated-internal-key

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,16 @@
+# ---------------------------------------
+# Frontend targets
+# ---------------------------------------
+# Gateway mode (default: SPA talks to the API Gateway and websocket proxies)
+VITE_API_BASE_URL=http://localhost:3000/api
+VITE_WS_GAME_URL=http://localhost:3000
+VITE_WS_GAME_PATH=/api/games/ws/socket.io
+
+# Local service mode (uncomment to bypass the gateway during debugging)
+# VITE_API_BASE_URL=http://localhost:3002
+# VITE_WS_GAME_URL=http://localhost:3002
+# VITE_WS_GAME_PATH=/ws/socket.io
+
+# OAuth redirect targets used by the gateway/service callbacks
+VITE_OAUTH_SUCCESS_REDIRECT=http://localhost:5173/auth/callback
+VITE_OAUTH_FAILURE_REDIRECT=http://localhost:5173/auth/error

--- a/infrastructure/api-gateway/.env.example
+++ b/infrastructure/api-gateway/.env.example
@@ -1,0 +1,38 @@
+# ---------------------------------------
+# Runtime
+# ---------------------------------------
+NODE_ENV=development
+LOG_LEVEL=info
+GATEWAY_PORT=3000
+
+# Public endpoints the SPA should call through the gateway
+PUBLIC_HTTP_URL=http://localhost:3000
+PUBLIC_WS_URL=ws://localhost:3000
+PUBLIC_WS_GAME_PATH=/api/games/ws/socket.io
+PUBLIC_WS_CHAT_PATH=/api/chat/ws
+
+# Downstream services the gateway proxies to (local defaults)
+USER_SERVICE_URL=http://localhost:3001
+GAME_SERVICE_URL=http://localhost:3002
+CHAT_SERVICE_URL=http://localhost:3003
+TOURNAMENT_SERVICE_URL=http://localhost:3004
+
+# CORS and rate limiting
+CORS_ORIGINS=http://localhost:3000
+RATE_LIMIT_MAX=100
+RATE_LIMIT_WINDOW=1 minute
+
+# Security
+INTERNAL_API_KEY=replace-with-generated-internal-key
+JWT_SECRET=placeholder-jwt-secret
+JWT_ISSUER=transcendence
+JWT_EXPIRATION_HOURS=24
+
+# OAuth redirects passed through to the user service
+OAUTH_SUCCESS_REDIRECT=http://localhost:5173/auth/callback
+OAUTH_FAILURE_REDIRECT=http://localhost:5173/auth/error
+
+# Vault (preferred) – falls back to the values above when unavailable
+VAULT_ADDR=http://localhost:8200
+VAULT_TOKEN=dev-root-token
+VAULT_SKIP_VERIFY=true

--- a/services/game-service/.env.example
+++ b/services/game-service/.env.example
@@ -1,5 +1,11 @@
+# ---------------------------------------
 # Networking
+# ---------------------------------------
 GAME_SERVICE_PORT=3002
+GAME_WS_PATH=/ws/socket.io
+GATEWAY_WS_GAME_PATH=/api/games/ws/socket.io
+GATEWAY_WS_CHAT_PATH=/api/chat/ws
+GATEWAY_HTTP_URL=http://localhost:3000
 
 # Gameplay defaults
 GAME_ROOM_CAPACITY=2
@@ -11,12 +17,19 @@ PADDLE_SPEED=8
 # Persistence
 GAME_DB_PATH=./data/game-service.db
 
+# Security
+INTERNAL_API_KEY=replace-with-generated-internal-key
+JWT_SECRET=placeholder-jwt-secret
+JWT_ISSUER=transcendence
+JWT_EXPIRATION_HOURS=24
+
 # External integrations
-INTERNAL_API_KEY=507003882d62345134d6cfb6eb86813e1821217989dd0302829448ec59118e4
 USER_SERVICE_URL=http://user-service:3001
 
+# Vault first (local values above act as fallbacks)
 VAULT_ADDR=http://localhost:8200
 VAULT_TOKEN=dev-root-token
+VAULT_SKIP_VERIFY=true
 
 # Redis (optional)
 REDIS_HOST=redis

--- a/services/user-service/.env.example
+++ b/services/user-service/.env.example
@@ -1,24 +1,40 @@
+# ---------------------------------------
 # User Service Configuration
+# ---------------------------------------
 USER_SERVICE_PORT=3001
 USER_SERVICE_HOST=0.0.0.0
 LOG_LEVEL=info
+GATEWAY_HTTP_URL=http://localhost:3000
+GATEWAY_WS_CHAT_PATH=/api/chat/ws
 
 # Security
-INTERNAL_API_KEY=your-internal-api-key-for-gateway
+INTERNAL_API_KEY=replace-with-generated-internal-key
 
 # Database
 DB_PATH=./data/users.db
 
-# Vault Configuration (for JWT secrets)
+# Vault configuration (preferred source for secrets)
 VAULT_ADDR=http://localhost:8200
 VAULT_TOKEN=dev-root-token
+VAULT_SKIP_VERIFY=true
 NODE_ENV=development
 
-# JWT Configuration (fallback if Vault is not available)
+# JWT configuration (fallback if Vault is not available)
 JWT_SECRET=your-super-secret-jwt-key-change-me-in-production
 JWT_ISSUER=transcendence
 JWT_EXPIRATION_HOURS=168
 REFRESH_TOKEN_TTL_DAYS=7
+
+# OAuth 42 settings
+OAUTH_42_CLIENT_ID=your-42-client-id
+OAUTH_42_CLIENT_SECRET=your-42-client-secret
+OAUTH_42_REDIRECT_URI=http://localhost:3000/api/auth/42/callback
+OAUTH_42_AUTHORIZE_URL=https://api.intra.42.fr/oauth/authorize
+OAUTH_42_TOKEN_URL=https://api.intra.42.fr/oauth/token
+OAUTH_42_PROFILE_URL=https://api.intra.42.fr/v2/me
+OAUTH_42_SCOPE=public
+OAUTH_42_SUCCESS_REDIRECT=http://localhost:5173/auth/callback
+OAUTH_42_FAILURE_REDIRECT=http://localhost:5173/auth/error
 
 # RabbitMQ (for future messaging integration)
 RABBITMQ_URL=amqp://guest:guest@localhost:5672


### PR DESCRIPTION
## Summary
- add .env.example files for the web SPA and API gateway with gateway/local defaults and OAuth redirects
- reformat root .env.example to clearly separate comments and include websocket and gateway settings
- update game and user service env examples with websocket paths, gateway URLs, and vault fallback notes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69295a11ee50832cb79a591083dc3356)