### PR TITLE
Update API base URL configuration for web client

### DIFF
--- a/apps/web/src/modules/shared/services/HttpClient.ts
+++ b/apps/web/src/modules/shared/services/HttpClient.ts
@@ -11,6 +11,11 @@ import type {
 import { authEvents } from '../utils/AuthEventEmitter';
 import { isTokenExpired } from '../utils/jwtUtils';
 
+const DEFAULT_API_URL = 'http://localhost:3000';
+
+export const API_BASE_URL = (import.meta?.env?.VITE_API_URL as string | undefined || DEFAULT_API_URL)
+  .replace(/\/+$/, '');
+
 export class ApiError extends Error {
   status: number;
   response?: unknown;
@@ -34,7 +39,7 @@ export class HttpClient {
   // Queue for requests waiting for token refresh
   private requestQueue: QueuedRequest[] = [];
 
-  constructor(baseURL: string) {
+  constructor(baseURL: string = API_BASE_URL) {
     this.baseURL = baseURL;
     this.setupDefaultInterceptors();
   }
@@ -437,7 +442,7 @@ export class HttpClient {
       throw new Error('No refresh token available');
     }
 
-    const response = await fetch(`${this.baseURL}/auth/refresh`, {
+    const response = await fetch(`${this.baseURL}/api/auth/refresh`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ refreshToken }),
@@ -467,7 +472,7 @@ export class HttpClient {
     // Try to revoke token on server
     if (refreshToken) {
       try {
-        await this.post('/auth/logout', { refreshToken });
+        await this.post('/api/auth/logout', { refreshToken });
         console.log('[HttpClient] ✅ Token revoked on server');
       } catch (error) {
         console.warn('[HttpClient] ⚠️ Failed to revoke token on server:', error);
@@ -541,7 +546,7 @@ export class HttpClient {
    * @param provider - OAuth provider ('42', 'google', 'github')
    */
   async initiateOAuthLogin(provider: '42' | 'google' | 'github' = '42'): Promise<void> {
-    const authUrl = `${this.baseURL}/auth/${provider}/login`;
+    const authUrl = `${this.baseURL}/api/auth/${provider}/login`;
     console.log('[HttpClient] 🔐 Initiating OAuth login with', provider);
 
     // Redirect to OAuth provider
@@ -591,8 +596,6 @@ export class HttpClient {
   }
 }
 
-export const httpClient = new HttpClient(
-   'http://localhost:3000/api'
-);
+export const httpClient = new HttpClient();
 
 export type { ApiResponse, RequestConfig } from '../types/http.types';

--- a/apps/web/src/services/api/ChatService.ts
+++ b/apps/web/src/services/api/ChatService.ts
@@ -1,9 +1,11 @@
 import { httpClient } from './client';
-import { 
-  ChatMessage, 
+import {
+  ChatMessage,
   Notification,
-  PaginatedResponse 
+  PaginatedResponse
 } from '../../models';
+
+const API_PREFIX = '/api';
 
 /**
  * Chat Service
@@ -14,7 +16,7 @@ export class ChatService {
    * Send a direct message to another user
    */
   async sendDirectMessage(recipientId: string, content: string): Promise<ChatMessage> {
-    const response = await httpClient.post<ChatMessage>('/chat/messages', {
+    const response = await httpClient.post<ChatMessage>(`${API_PREFIX}/chat/messages`, {
       recipientId,
       content,
       type: 'text'
@@ -26,7 +28,7 @@ export class ChatService {
    * Send a game invitation through chat
    */
   async sendGameInvitation(recipientId: string, gameId: string): Promise<ChatMessage> {
-    const response = await httpClient.post<ChatMessage>('/chat/messages', {
+    const response = await httpClient.post<ChatMessage>(`${API_PREFIX}/chat/messages`, {
       recipientId,
       content: `Game invitation: ${gameId}`,
       type: 'game_invite',
@@ -40,11 +42,11 @@ export class ChatService {
    */
   async getDirectMessages(
     userId: string, 
-    page = 1, 
+    page = 1,
     limit = 50
   ): Promise<PaginatedResponse<ChatMessage>> {
     const response = await httpClient.get<PaginatedResponse<ChatMessage>>(
-      `/chat/messages/direct/${userId}?page=${page}&limit=${limit}`
+      `${API_PREFIX}/chat/messages/direct/${userId}?page=${page}&limit=${limit}`
     );
     return response.data!;
   }
@@ -65,7 +67,7 @@ export class ChatService {
       avatar?: string;
       lastMessage?: ChatMessage;
       unreadCount: number;
-    }>>('/chat/conversations');
+    }>>(`${API_PREFIX}/chat/conversations`);
     return response.data!;
   }
 
@@ -73,7 +75,7 @@ export class ChatService {
    * Mark messages as read
    */
   async markAsRead(userId: string): Promise<void> {
-    await httpClient.post(`/chat/conversations/${userId}/read`);
+    await httpClient.post(`${API_PREFIX}/chat/conversations/${userId}/read`);
   }
 
   /**
@@ -81,7 +83,7 @@ export class ChatService {
    */
   async getNotifications(page = 1, limit = 20): Promise<PaginatedResponse<Notification>> {
     const response = await httpClient.get<PaginatedResponse<Notification>>(
-      `/notifications?page=${page}&limit=${limit}`
+      `${API_PREFIX}/notifications?page=${page}&limit=${limit}`
     );
     return response.data!;
   }
@@ -90,28 +92,28 @@ export class ChatService {
    * Mark notification as read
    */
   async markNotificationAsRead(notificationId: string): Promise<void> {
-    await httpClient.patch(`/notifications/${notificationId}/read`);
+    await httpClient.patch(`${API_PREFIX}/notifications/${notificationId}/read`);
   }
 
   /**
    * Mark all notifications as read
    */
   async markAllNotificationsAsRead(): Promise<void> {
-    await httpClient.patch('/notifications/read-all');
+    await httpClient.patch(`${API_PREFIX}/notifications/read-all`);
   }
 
   /**
    * Delete notification
    */
   async deleteNotification(notificationId: string): Promise<void> {
-    await httpClient.delete(`/notifications/${notificationId}`);
+    await httpClient.delete(`${API_PREFIX}/notifications/${notificationId}`);
   }
 
   /**
    * Get unread notification count
    */
   async getUnreadCount(): Promise<{ messages: number; notifications: number }> {
-    const response = await httpClient.get<{ messages: number; notifications: number }>('/chat/unread-count');
+    const response = await httpClient.get<{ messages: number; notifications: number }>(`${API_PREFIX}/chat/unread-count`);
     return response.data!;
   }
 
@@ -119,14 +121,14 @@ export class ChatService {
    * Block user from sending messages
    */
   async blockUser(userId: string): Promise<void> {
-    await httpClient.post('/chat/block', { userId });
+    await httpClient.post(`${API_PREFIX}/chat/block`, { userId });
   }
 
   /**
    * Unblock user
    */
   async unblockUser(userId: string): Promise<void> {
-    await httpClient.delete(`/chat/block/${userId}`);
+    await httpClient.delete(`${API_PREFIX}/chat/block/${userId}`);
   }
 
   /**
@@ -141,7 +143,7 @@ export class ChatService {
       userId: string;
       username: string;
       blockedAt: string;
-    }>>('/chat/blocked');
+    }>>(`${API_PREFIX}/chat/blocked`);
     return response.data!;
   }
 
@@ -149,7 +151,7 @@ export class ChatService {
    * Delete conversation (clear message history)
    */
   async deleteConversation(userId: string): Promise<void> {
-    await httpClient.delete(`/chat/conversations/${userId}`);
+    await httpClient.delete(`${API_PREFIX}/chat/conversations/${userId}`);
   }
 }
 

--- a/apps/web/src/services/api/GameService.ts
+++ b/apps/web/src/services/api/GameService.ts
@@ -1,11 +1,13 @@
 import { httpClient } from './client';
-import { 
-  Game, 
-  GameDTOs, 
-  GameState, 
+import {
+  Game,
+  GameDTOs,
+  GameState,
   Match,
-  PaginatedResponse 
+  PaginatedResponse
 } from '../../models';
+
+const API_PREFIX = '/api';
 
 /**
  * Game Service
@@ -16,7 +18,7 @@ export class GameService {
    * Create a new game
    */
   async createGame(request: GameDTOs.CreateGameRequest): Promise<GameDTOs.CreateGameResponse> {
-    const response = await httpClient.post<GameDTOs.CreateGameResponse>('/games', request);
+    const response = await httpClient.post<GameDTOs.CreateGameResponse>(`${API_PREFIX}/games`, request);
     return response.data!;
   }
 
@@ -24,7 +26,7 @@ export class GameService {
    * Join an existing game
    */
   async joinGame(request: GameDTOs.JoinGameRequest): Promise<GameDTOs.JoinGameResponse> {
-    const response = await httpClient.post<GameDTOs.JoinGameResponse>('/games/join', request);
+    const response = await httpClient.post<GameDTOs.JoinGameResponse>(`${API_PREFIX}/games/join`, request);
     return response.data!;
   }
 
@@ -32,14 +34,14 @@ export class GameService {
    * Leave a game
    */
   async leaveGame(gameId: string): Promise<void> {
-    await httpClient.post(`/games/${gameId}/leave`);
+    await httpClient.post(`${API_PREFIX}/games/${gameId}/leave`);
   }
 
   /**
    * Get game details
    */
   async getGame(gameId: string): Promise<Game> {
-    const response = await httpClient.get<Game>(`/games/${gameId}`);
+    const response = await httpClient.get<Game>(`${API_PREFIX}/games/${gameId}`);
     return response.data!;
   }
 
@@ -47,7 +49,7 @@ export class GameService {
    * Get current game state
    */
   async getGameState(gameId: string): Promise<GameState> {
-    const response = await httpClient.get<GameState>(`/games/${gameId}/state`);
+    const response = await httpClient.get<GameState>(`${API_PREFIX}/games/${gameId}/state`);
     return response.data!;
   }
 
@@ -55,21 +57,21 @@ export class GameService {
    * Send player move input
    */
   async sendMoveInput(gameId: string, input: GameDTOs.MoveInput): Promise<void> {
-    await httpClient.post(`/games/${gameId}/move`, input);
+    await httpClient.post(`${API_PREFIX}/games/${gameId}/move`, input);
   }
 
   /**
    * Start a game (for game creator)
    */
   async startGame(gameId: string): Promise<void> {
-    await httpClient.post(`/games/${gameId}/start`);
+    await httpClient.post(`${API_PREFIX}/games/${gameId}/start`);
   }
 
   /**
    * Cancel a game (for game creator or admin)
    */
   async cancelGame(gameId: string): Promise<void> {
-    await httpClient.post(`/games/${gameId}/cancel`);
+    await httpClient.post(`${API_PREFIX}/games/${gameId}/cancel`);
   }
 
   /**
@@ -77,7 +79,7 @@ export class GameService {
    */
   async getAvailableGames(page = 1, limit = 20): Promise<GameDTOs.GameListResponse> {
     const response = await httpClient.get<GameDTOs.GameListResponse>(
-      `/games/available?page=${page}&limit=${limit}`
+      `${API_PREFIX}/games/available?page=${page}&limit=${limit}`
     );
     return response.data!;
   }
@@ -86,7 +88,7 @@ export class GameService {
    * Get list of user's games (current and completed)
    */
   async getMyGames(status?: 'waiting' | 'playing' | 'finished', page = 1, limit = 20): Promise<GameDTOs.GameListResponse> {
-    let endpoint = `/games/me?page=${page}&limit=${limit}`;
+    let endpoint = `${API_PREFIX}/games/me?page=${page}&limit=${limit}`;
     if (status) {
       endpoint += `&status=${status}`;
     }
@@ -99,7 +101,7 @@ export class GameService {
    * Get match details (completed game)
    */
   async getMatch(matchId: string): Promise<Match> {
-    const response = await httpClient.get<Match>(`/matches/${matchId}`);
+    const response = await httpClient.get<Match>(`${API_PREFIX}/matches/${matchId}`);
     return response.data!;
   }
 
@@ -108,7 +110,7 @@ export class GameService {
    */
   async getRecentMatches(page = 1, limit = 20): Promise<PaginatedResponse<Match>> {
     const response = await httpClient.get<PaginatedResponse<Match>>(
-      `/matches/recent?page=${page}&limit=${limit}`
+      `${API_PREFIX}/matches/recent?page=${page}&limit=${limit}`
     );
     return response.data!;
   }
@@ -117,7 +119,7 @@ export class GameService {
    * Invite user to a game
    */
   async invitePlayer(gameId: string, userId: string): Promise<void> {
-    await httpClient.post(`/games/${gameId}/invite`, { userId });
+    await httpClient.post(`${API_PREFIX}/games/${gameId}/invite`, { userId });
   }
 
   /**
@@ -125,7 +127,7 @@ export class GameService {
    */
   async acceptInvitation(invitationId: string): Promise<GameDTOs.JoinGameResponse> {
     const response = await httpClient.post<GameDTOs.JoinGameResponse>(
-      `/games/invitations/${invitationId}/accept`
+      `${API_PREFIX}/games/invitations/${invitationId}/accept`
     );
     return response.data!;
   }
@@ -134,7 +136,7 @@ export class GameService {
    * Decline game invitation
    */
   async declineInvitation(invitationId: string): Promise<void> {
-    await httpClient.post(`/games/invitations/${invitationId}/decline`);
+    await httpClient.post(`${API_PREFIX}/games/invitations/${invitationId}/decline`);
   }
 
   /**
@@ -153,7 +155,7 @@ export class GameService {
       game: Game;
       invitedBy: string;
       createdAt: string;
-    }>>('/games/invitations');
+    }>>(`${API_PREFIX}/games/invitations`);
     return response.data!;
   }
 
@@ -161,7 +163,7 @@ export class GameService {
    * Find match (matchmaking)
    */
   async findMatch(gameType: 'pong' | 'custom' = 'pong'): Promise<GameDTOs.JoinGameResponse> {
-    const response = await httpClient.post<GameDTOs.JoinGameResponse>('/games/matchmaking', { gameType });
+    const response = await httpClient.post<GameDTOs.JoinGameResponse>(`${API_PREFIX}/games/matchmaking`, { gameType });
     return response.data!;
   }
 
@@ -169,7 +171,7 @@ export class GameService {
    * Cancel matchmaking
    */
   async cancelMatchmaking(): Promise<void> {
-    await httpClient.delete('/games/matchmaking');
+    await httpClient.delete(`${API_PREFIX}/games/matchmaking`);
   }
 }
 

--- a/apps/web/src/services/api/TournamentService.ts
+++ b/apps/web/src/services/api/TournamentService.ts
@@ -1,10 +1,12 @@
 import { httpClient } from './client';
-import { 
-  Tournament, 
-  TournamentDTOs, 
+import {
+  Tournament,
+  TournamentDTOs,
   TournamentMatch,
-  TournamentLeaderboard 
+  TournamentLeaderboard
 } from '../../models';
+
+const API_PREFIX = '/api';
 
 /**
  * Tournament Service
@@ -15,7 +17,7 @@ export class TournamentService {
    * Create a new tournament
    */
   async createTournament(request: TournamentDTOs.CreateTournamentRequest): Promise<TournamentDTOs.CreateTournamentResponse> {
-    const response = await httpClient.post<TournamentDTOs.CreateTournamentResponse>('/tournaments', request);
+    const response = await httpClient.post<TournamentDTOs.CreateTournamentResponse>(`${API_PREFIX}/tournaments`, request);
     return response.data!;
   }
 
@@ -23,7 +25,7 @@ export class TournamentService {
    * Get tournament details
    */
   async getTournament(tournamentId: string): Promise<Tournament> {
-    const response = await httpClient.get<Tournament>(`/tournaments/${tournamentId}`);
+    const response = await httpClient.get<Tournament>(`${API_PREFIX}/tournaments/${tournamentId}`);
     return response.data!;
   }
 
@@ -35,7 +37,7 @@ export class TournamentService {
     page = 1, 
     limit = 20
   ): Promise<TournamentDTOs.TournamentListResponse> {
-    let endpoint = `/tournaments?page=${page}&limit=${limit}`;
+    let endpoint = `${API_PREFIX}/tournaments?page=${page}&limit=${limit}`;
     if (status) {
       endpoint += `&status=${status}`;
     }
@@ -52,7 +54,7 @@ export class TournamentService {
     request: TournamentDTOs.RegisterForTournamentRequest
   ): Promise<TournamentDTOs.RegisterForTournamentResponse> {
     const response = await httpClient.post<TournamentDTOs.RegisterForTournamentResponse>(
-      `/tournaments/${tournamentId}/register`, 
+      `${API_PREFIX}/tournaments/${tournamentId}/register`,
       request
     );
     return response.data!;
@@ -62,7 +64,7 @@ export class TournamentService {
    * Unregister from a tournament (before it starts)
    */
   async unregisterFromTournament(tournamentId: string): Promise<void> {
-    await httpClient.delete(`/tournaments/${tournamentId}/register`);
+    await httpClient.delete(`${API_PREFIX}/tournaments/${tournamentId}/register`);
   }
 
   /**
@@ -70,7 +72,7 @@ export class TournamentService {
    */
   async startTournament(tournamentId: string): Promise<TournamentDTOs.StartTournamentResponse> {
     const response = await httpClient.post<TournamentDTOs.StartTournamentResponse>(
-      `/tournaments/${tournamentId}/start`
+      `${API_PREFIX}/tournaments/${tournamentId}/start`
     );
     return response.data!;
   }
@@ -79,14 +81,14 @@ export class TournamentService {
    * Cancel a tournament (for tournament creator or admin)
    */
   async cancelTournament(tournamentId: string): Promise<void> {
-    await httpClient.post(`/tournaments/${tournamentId}/cancel`);
+    await httpClient.post(`${API_PREFIX}/tournaments/${tournamentId}/cancel`);
   }
 
   /**
    * Get tournament matches
    */
   async getTournamentMatches(tournamentId: string, round?: number): Promise<TournamentMatch[]> {
-    let endpoint = `/tournaments/${tournamentId}/matches`;
+    let endpoint = `${API_PREFIX}/tournaments/${tournamentId}/matches`;
     if (round !== undefined) {
       endpoint += `?round=${round}`;
     }
@@ -99,7 +101,7 @@ export class TournamentService {
    * Get tournament bracket
    */
   async getTournamentBracket(tournamentId: string): Promise<Tournament['bracket']> {
-    const response = await httpClient.get<Tournament['bracket']>(`/tournaments/${tournamentId}/bracket`);
+    const response = await httpClient.get<Tournament['bracket']>(`${API_PREFIX}/tournaments/${tournamentId}/bracket`);
     return response.data!;
   }
 
@@ -108,7 +110,7 @@ export class TournamentService {
    */
   async getTournamentLeaderboard(tournamentId: string): Promise<TournamentDTOs.TournamentLeaderboardResponse> {
     const response = await httpClient.get<TournamentDTOs.TournamentLeaderboardResponse>(
-      `/tournaments/${tournamentId}/leaderboard`
+      `${API_PREFIX}/tournaments/${tournamentId}/leaderboard`
     );
     return response.data!;
   }
@@ -122,7 +124,7 @@ export class TournamentService {
     limit = 20
   ): Promise<TournamentDTOs.TournamentListResponse> {
     const response = await httpClient.get<TournamentDTOs.TournamentListResponse>(
-      `/tournaments/me?type=${type}&page=${page}&limit=${limit}`
+      `${API_PREFIX}/tournaments/me?type=${type}&page=${page}&limit=${limit}`
     );
     return response.data!;
   }
@@ -132,7 +134,7 @@ export class TournamentService {
    */
   async getMyNextMatch(tournamentId: string): Promise<TournamentMatch | null> {
     try {
-      const response = await httpClient.get<TournamentMatch>(`/tournaments/${tournamentId}/my-next-match`);
+      const response = await httpClient.get<TournamentMatch>(`${API_PREFIX}/tournaments/${tournamentId}/my-next-match`);
       return response.data!;
     } catch (error) {
       // No next match available
@@ -160,7 +162,7 @@ export class TournamentService {
       totalRounds: number;
       startedAt?: string;
       estimatedEndTime?: string;
-    }>(`/tournaments/${tournamentId}/stats`);
+    }>(`${API_PREFIX}/tournaments/${tournamentId}/stats`);
     return response.data!;
   }
 
@@ -168,10 +170,10 @@ export class TournamentService {
    * Update tournament settings (for tournament creator)
    */
   async updateTournament(
-    tournamentId: string, 
+    tournamentId: string,
     updates: Partial<TournamentDTOs.CreateTournamentRequest>
   ): Promise<Tournament> {
-    const response = await httpClient.patch<Tournament>(`/tournaments/${tournamentId}`, updates);
+    const response = await httpClient.patch<Tournament>(`${API_PREFIX}/tournaments/${tournamentId}`, updates);
     return response.data!;
   }
 
@@ -179,7 +181,7 @@ export class TournamentService {
    * Delete tournament (for tournament creator or admin)
    */
   async deleteTournament(tournamentId: string): Promise<void> {
-    await httpClient.delete(`/tournaments/${tournamentId}`);
+    await httpClient.delete(`${API_PREFIX}/tournaments/${tournamentId}`);
   }
 }
 

--- a/apps/web/src/services/api/UserService.ts
+++ b/apps/web/src/services/api/UserService.ts
@@ -1,12 +1,14 @@
 import { httpClient } from './client';
-import { 
-  User, 
-  UserProfile, 
-  Friend, 
-  UserDTOs, 
+import {
+  User,
+  UserProfile,
+  Friend,
+  UserDTOs,
   PaginatedResponse,
-  Match 
+  Match
 } from '../../models';
+
+const API_PREFIX = '/api';
 
 /**
  * User Service
@@ -17,7 +19,7 @@ export class UserService {
    * Get current user profile
    */
   async getMe(): Promise<User> {
-    const response = await httpClient.get<User>('/users/me');
+    const response = await httpClient.get<User>(`${API_PREFIX}/users/me`);
     return response.data!;
   }
 
@@ -25,7 +27,7 @@ export class UserService {
    * Get detailed user profile with stats and match history
    */
   async getProfile(userId?: string): Promise<UserProfile> {
-    const endpoint = userId ? `/users/${userId}` : '/users/me/profile';
+    const endpoint = userId ? `${API_PREFIX}/users/${userId}` : `${API_PREFIX}/users/me/profile`;
     const response = await httpClient.get<UserProfile>(endpoint);
     return response.data!;
   }
@@ -48,7 +50,7 @@ export class UserService {
       body = { username: request.username };
     }
 
-    const response = await httpClient.patch<UserDTOs.UpdateProfileResponse>('/users/me', body);
+    const response = await httpClient.patch<UserDTOs.UpdateProfileResponse>(`${API_PREFIX}/users/me`, body);
     return response.data!;
   }
 
@@ -56,7 +58,7 @@ export class UserService {
    * Search users by username or email
    */
   async searchUsers(query: string, limit = 10): Promise<User[]> {
-    const response = await httpClient.get<User[]>('/users/search', {
+    const response = await httpClient.get<User[]>(`${API_PREFIX}/users/search`, {
       headers: {
         'Accept': 'application/json'
       }
@@ -71,7 +73,7 @@ export class UserService {
    * Get user's friends list
    */
   async getFriends(): Promise<Friend[]> {
-    const response = await httpClient.get<Friend[]>('/users/me/friends');
+    const response = await httpClient.get<Friend[]>(`${API_PREFIX}/users/me/friends`);
     return response.data!;
   }
 
@@ -79,21 +81,21 @@ export class UserService {
    * Send friend request to a user
    */
   async addFriend(request: UserDTOs.AddFriendRequest): Promise<void> {
-    await httpClient.post('/users/me/friends', request);
+    await httpClient.post(`${API_PREFIX}/users/me/friends`, request);
   }
 
   /**
    * Remove a friend
    */
   async removeFriend(userId: string): Promise<void> {
-    await httpClient.delete(`/users/me/friends/${userId}`);
+    await httpClient.delete(`${API_PREFIX}/users/me/friends/${userId}`);
   }
 
   /**
    * Get pending friend requests
    */
   async getFriendRequests(): Promise<{ sent: User[]; received: User[] }> {
-    const response = await httpClient.get<{ sent: User[]; received: User[] }>('/users/me/friend-requests');
+    const response = await httpClient.get<{ sent: User[]; received: User[] }>(`${API_PREFIX}/users/me/friend-requests`);
     return response.data!;
   }
 
@@ -101,21 +103,21 @@ export class UserService {
    * Accept a friend request
    */
   async acceptFriendRequest(userId: string): Promise<void> {
-    await httpClient.post(`/users/me/friend-requests/${userId}/accept`);
+    await httpClient.post(`${API_PREFIX}/users/me/friend-requests/${userId}/accept`);
   }
 
   /**
    * Reject a friend request
    */
   async rejectFriendRequest(userId: string): Promise<void> {
-    await httpClient.post(`/users/me/friend-requests/${userId}/reject`);
+    await httpClient.post(`${API_PREFIX}/users/me/friend-requests/${userId}/reject`);
   }
 
   /**
    * Get user's match history
    */
   async getMatchHistory(userId?: string, page = 1, limit = 20): Promise<PaginatedResponse<Match>> {
-    const endpoint = userId ? `/users/${userId}/matches` : '/users/me/matches';
+    const endpoint = userId ? `${API_PREFIX}/users/${userId}/matches` : `${API_PREFIX}/users/me/matches`;
     const response = await httpClient.get<PaginatedResponse<Match>>(
       `${endpoint}?page=${page}&limit=${limit}`
     );
@@ -126,28 +128,28 @@ export class UserService {
    * Update user status (online, offline, in-game)
    */
   async updateStatus(status: 'ONLINE' | 'OFFLINE' | 'INGAME'): Promise<void> {
-    await httpClient.patch('/users/me/status', { status });
+    await httpClient.patch(`${API_PREFIX}/users/me/status`, { status });
   }
 
   /**
    * Block a user
    */
   async blockUser(userId: string): Promise<void> {
-    await httpClient.post(`/users/me/blocked`, { userId });
+    await httpClient.post(`${API_PREFIX}/users/me/blocked`, { userId });
   }
 
   /**
    * Unblock a user
    */
   async unblockUser(userId: string): Promise<void> {
-    await httpClient.delete(`/users/me/blocked/${userId}`);
+    await httpClient.delete(`${API_PREFIX}/users/me/blocked/${userId}`);
   }
 
   /**
    * Get list of blocked users
    */
   async getBlockedUsers(): Promise<User[]> {
-    const response = await httpClient.get<User[]>('/users/me/blocked');
+    const response = await httpClient.get<User[]>(`${API_PREFIX}/users/me/blocked`);
     return response.data!;
   }
 
@@ -155,7 +157,7 @@ export class UserService {
    * Delete user account
    */
   async deleteAccount(): Promise<void> {
-    await httpClient.delete('/users/me');
+    await httpClient.delete(`${API_PREFIX}/users/me`);
     // Clear auth token after account deletion
     httpClient.clearAuthToken();
   }

--- a/apps/web/src/services/api/client.ts
+++ b/apps/web/src/services/api/client.ts
@@ -1,7 +1,7 @@
-import { HttpClient } from '../../modules/shared/services/HttpClient';
+import { API_BASE_URL, HttpClient } from '../../modules/shared/services/HttpClient';
 
 /**
  * Shared HttpClient instance used by vanilla services.
  * Keeping it in its own module avoids confusing the class definition file.
  */
-export const httpClient = new HttpClient('/api');
+export const httpClient = new HttpClient(API_BASE_URL);

--- a/apps/web/src/services/auth/AuthService.ts
+++ b/apps/web/src/services/auth/AuthService.ts
@@ -20,7 +20,7 @@ export class AuthService {
    * POST /auth/signup
    */
   async signup(data: SignUpRequest): Promise<User> {
-    const response = await this.httpClient.post<User>('/auth/signup', data);
+    const response = await this.httpClient.post<User>('/api/auth/signup', data);
     return response.data!;
   }
 
@@ -45,7 +45,7 @@ export class AuthService {
     credentials: LoginRequest & { twoFACode?: string }
   ): Promise<LoginResponse> {
     const response = await this.httpClient.post<LoginResponse>(
-      '/auth/login',
+      '/api/auth/login',
       credentials
     );
     this.persistSession(response.user.id);
@@ -58,7 +58,7 @@ export class AuthService {
    */
   async getStatus(): Promise<User | null> {
     try {
-      const response = await this.httpClient.get<User>('/auth/status');
+      const response = await this.httpClient.get<User>('/api/auth/status');
       return response ?? null;
     } catch (error) {
       if (error instanceof Error && error.message.includes('401')) {
@@ -74,7 +74,7 @@ export class AuthService {
    */
   async logout(): Promise<void> {
     try {
-      await this.httpClient.post<void>('/auth/logout', {});
+      await this.httpClient.post<void>('/api/auth/logout', {});
     } catch (error) {
       console.warn('Logout failed:', error);
     }
@@ -85,7 +85,7 @@ export class AuthService {
    */
   async start42Login(): Promise<OAuthAuthorizationResponse> {
     const response = await this.httpClient.get<OAuthAuthorizationResponse>(
-      '/auth/42/login'
+      '/api/auth/42/login'
     );
     return response ?? {
       authorizationUrl: `${window.location.origin}/auth/42/login`,
@@ -94,7 +94,7 @@ export class AuthService {
 
   async handle42Callback(code: string, state: string): Promise<LoginResponse> {
     const response = await this.httpClient.get<LoginResponse>(
-      `/auth/42/callback?code=${encodeURIComponent(code)}&state=${encodeURIComponent(
+      `/api/auth/42/callback?code=${encodeURIComponent(code)}&state=${encodeURIComponent(
         state
       )}`
     );


### PR DESCRIPTION
## Summary
- derive the shared HttpClient base URL from VITE_API_URL (defaulting to http://localhost:3000) and target /api auth endpoints explicitly
- update web API service endpoints to include the /api prefix now that the base URL no longer embeds it
- keep game service routes aligned with the gateway base path while using the new API host configuration

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cc87bcfe8832c9b48fa7f48c026a9)